### PR TITLE
Remove curly braces for array element access

### DIFF
--- a/HTML/Safe.php
+++ b/HTML/Safe.php
@@ -272,7 +272,7 @@ class HTML_Safe
         foreach ($this->blackProtocols as $proto) {
             $preg = "/[\s\x01-\x1F]*";
             for ($i=0; $i<strlen($proto); $i++) {
-                $preg .= $proto{$i} . "[\s\x01-\x1F]*";
+                $preg .= $proto[$i] . "[\s\x01-\x1F]*";
             }
             $preg .= ":/i";
             $this->protoRegexps[] = $preg;


### PR DESCRIPTION
Access array element using curly braces has been deprecated since PHP 7.4 and removed in PHP 8.1.