### PR TITLE
PSR-2 compliancy - Convert line separator from CRLF to LF and fix typos

### DIFF
--- a/HTML/Safe.php
+++ b/HTML/Safe.php
@@ -627,7 +627,7 @@ class HTML_Safe
     }
 
     /**
-     * Main parsing fuction
+     * Main parsing function
      *
      * @param string $doc HTML document for processing
      *
@@ -663,7 +663,7 @@ class HTML_Safe
     }
 
     /**
-     * UTF-7 decoding fuction
+     * UTF-7 decoding function
      *
      * @param string $str HTML document for recode ASCII part of UTF-7 back to ASCII
      * @return string Decoded document
@@ -675,7 +675,7 @@ class HTML_Safe
     }
 
     /**
-     * Additional UTF-7 decoding fuction
+     * Additional UTF-7 decoding function
      *
      * @param string $str String for recode ASCII part of UTF-7 back to ASCII
      * @return string Recoded string
@@ -689,7 +689,7 @@ class HTML_Safe
     }
 
     /**
-     * Additional UTF-7 encoding fuction
+     * Additional UTF-7 encoding function
      *
      * @param string $str String for recode ASCII part of UTF-7 back to ASCII
      * @return string Recoded string

--- a/tests/HTML_SafeTest.php
+++ b/tests/HTML_SafeTest.php
@@ -8,12 +8,12 @@ class HTML_SafeTest extends TestCase
 {
     public function testAllowTags()
     {
-        $input    = '<html><body><p>my text</p></body></html>'; 
+        $input    = '<html><body><p>my text</p></body></html>';
         $expected = '<body><p>my text</p></body>';
 
         $safe = new HTML_Safe;
         $safe->setAllowTags(array('body'));
-        $this->assertSame($expected, $safe->parse($input)); 
+        $this->assertSame($expected, $safe->parse($input));
     }
 
     public function testSpecialChars()


### PR DESCRIPTION
Convert PHP files line separator from CRLF to LF and fix some typos