### PR TITLE
Drop support PHP before 5.3.3 and improve tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/pear/HTML_Safe"
     },
     "require": {
-        "php": ">=5.2",
+        "php": ">=5.3.3",
         "pear/pear_exception": "*",
         "pear/xml_htmlsax3": "*"
     },

--- a/package.xml
+++ b/package.xml
@@ -35,7 +35,7 @@
  <dependencies>
   <required>
    <php>
-    <min>5.2</min>
+    <min>5.3.3</min>
    </php>
    <pearinstaller>
     <min>1.6</min>

--- a/tests/HTML_SafeTest.php
+++ b/tests/HTML_SafeTest.php
@@ -1,6 +1,11 @@
 <?php
 
-require_once 'PHPUnit/Framework/TestCase.php';
+// Include PHPUnit using composer
+if (is_readable('vendor/autoload.php')) {
+    require_once 'vendor/autoload.php';
+} else {
+    require_once 'PHPUnit/Framework/TestCase.php';
+}
 require_once 'HTML/Safe.php';
 
 use PHPUnit\Framework\TestCase;

--- a/tests/HTML_SafeTest.php
+++ b/tests/HTML_SafeTest.php
@@ -34,4 +34,53 @@ class HTML_SafeTest extends TestCase
         $this->assertSame($expectedOne, $safe->parse($inputOne));
         $this->assertSame($expectedTwo, $safe->parse($inputTwo));
     }
+
+    public function testMissingClosureTag()
+    {
+        $input = '<div><span>my text with missing tag closure</div>';
+        $expected = '<div><span>my text with missing tag closure</span></div>';
+
+        $safe = new HTML_Safe();
+        $this->assertSame($expected, $safe->parse($input));
+    }
+
+    public function testMissingOpenTag()
+    {
+        $input = '<div>my text with missing tag opening</span></div>';
+        $expected = '<div>my text with missing tag opening</div>';
+
+        $safe = new HTML_Safe();
+        $this->assertSame($expected, $safe->parse($input));
+    }
+
+    public function testParagraphClosure()
+    {
+        $input = '<div><h1>my first title</h1><p>my text<h1>my second title</h1></p></div>';
+        $expected = '<div><h1>my first title</h1><p>my text</p><h1>my second title</h1></div>';
+
+        $safe = new HTML_Safe();
+        $this->assertSame($expected, $safe->parse($input));
+    }
+
+    public function testSingleTags()
+    {
+        $inputOne = '<img src="not-exist.jpg" alt="Test image">';
+        $expectedOne = '<img src="not-exist.jpg" alt="Test image" />';
+
+        $inputTwo = '<img src="not-exist.jpg" alt="Test image">TEST</img>';
+        $expectedTwo = '<img src="not-exist.jpg" alt="Test image" />TEST';
+
+        $safe = new HTML_Safe();
+        $this->assertSame($expectedOne, $safe->parse($inputOne));
+        $this->assertSame($expectedTwo, $safe->parse($inputTwo));
+    }
+
+    public function testInsecureTags()
+    {
+        $input = '<div>Iframe content:<iframe title="Github iframe" width="300" height="200" src="https://github.com"></iframe></div>';
+        $expected = '<div>Iframe content:</div>';
+
+        $safe = new HTML_Safe();
+        $this->assertSame($expected, $safe->parse($input));
+    }
 }


### PR DESCRIPTION
The first PHPUnit relase available using composer require PHP 5.3.3 so I update the php required version and modified PHPUnit inclusion in tests to support composer autoloader.

I have also add some tests for: missing closure tag, missing open tag, paragraph closure, single tag and insecure tag.